### PR TITLE
Fix #15 modify cli interface

### DIFF
--- a/lib/gver_diff/cli.ex
+++ b/lib/gver_diff/cli.ex
@@ -1,29 +1,21 @@
 defmodule GverDiff.CLI do
   def main(args) do
-    {options, _, _} =
+    {options, arg, _} =
       OptionParser.parse(
         args,
         strict: [
-          base: :string,
-          target: :string,
-          type: :string,
-          operator: :string
+          type: :string
         ],
         aliases: [
-          t: :type,
-          o: :operator
+          t: :type
         ]
       )
 
-    options
-    |> Enum.into(%{})
+    [base, operator, target] = arg
+
+    %{:base => base, :target => target}
     |> GverDiff.OptionConverter.convert(options[:type])
-    |> GverDiff.OptionComparer.compare?(options[:operator])
-    |> if do
-      IO.puts("OK !!")
-    else
-      IO.puts("Error !!")
-      exit({:shutdown, 1})
-    end
+    |> GverDiff.OptionComparer.compare?(operator)
+    |> IO.puts()
   end
 end

--- a/test/gver_diff/cli_test.exs
+++ b/test/gver_diff/cli_test.exs
@@ -3,14 +3,13 @@ defmodule CLITest do
   import ExUnit.CaptureIO
 
   test "Normal" do
-    expect = "OK !!\n"
+    expect = "true\n"
 
     actual =
       capture_io(fn ->
         GverDiff.CLI.main([
-          "--base",
           "2",
-          "--target",
+          "<",
           "3"
         ])
       end)
@@ -18,18 +17,17 @@ defmodule CLITest do
     assert expect == actual
   end
 
-  test "Specified Operator" do
-    expect = "OK !!\n"
+  test "Specified Type" do
+    expect = "true\n"
 
     actual =
       capture_io(fn ->
         GverDiff.CLI.main([
-          "--base",
-          "3",
-          "--target",
-          "2",
-          "-o",
-          ">"
+          "--type",
+          "datetime",
+          "2019-11-11 12:12:12",
+          "<",
+          "2019-12-12 13:13:13"
         ])
       end)
 
@@ -37,33 +35,31 @@ defmodule CLITest do
   end
 
   test "Abnormal" do
-    expect = 1
+    expect = "false\n"
 
-    {_, actual} =
-      GverDiff.CLI.main([
-        "--base",
-        "3",
-        "--target",
-        "2"
-      ])
-      |> catch_exit
+    actual =
+      capture_io(fn ->
+        GverDiff.CLI.main([
+          "3",
+          "<",
+          "2"
+        ])
+      end)
 
     assert expect == actual
   end
 
   test "Abnormal Operator" do
-    expect = 1
+    expect = "false\n"
 
-    {_, actual} =
-      GverDiff.CLI.main([
-        "--base",
-        "3",
-        "--target",
-        "2",
-        "-o",
-        "hoge"
-      ])
-      |> catch_exit
+    actual =
+      capture_io(fn ->
+        GverDiff.CLI.main([
+          "3",
+          "hoge",
+          "2"
+        ])
+      end)
 
     assert expect == actual
   end


### PR DESCRIPTION
before

```
$ gv_diff --base=2 --target=3 --operator=lt --type=integer
OK !!
```

after

```
~/work/gver_diff ya-sato@issue/15*
❯ bin/gver_diff --type datetime "2019-12-12 11:11:11" lt "2019-11-11 12:12:12"
false

~/work/gver_diff ya-sato@issue/15*
❯ bin/gver_diff --type datetime "2019-12-12 11:11:11" gt "2019-11-11 12:12:12"
true

```